### PR TITLE
Dynamic Prompt System for Video Model Training

### DIFF
--- a/prompts/METADATA_USAGE.md
+++ b/prompts/METADATA_USAGE.md
@@ -1,0 +1,200 @@
+# Metadata Generation Tool
+
+## Overview
+
+Generate metadata.csv files for VR-Bench dataset with dynamic prompts based on skin configurations.
+
+**Features:**
+- Dynamic prompt generation from skin descriptions
+- Flexible filtering by game type, skin, and difficulty
+- Separate or merged output modes
+- Support for both train and eval splits
+
+## Quick Start
+
+```bash
+# Generate all metadata files
+python test_dynamic_metadata.py
+
+# Generate for specific game type
+python test_dynamic_metadata.py --games maze
+
+# Generate for specific skins and difficulties
+python test_dynamic_metadata.py --games maze --skins 1 2 --difficulties easy
+```
+
+## Command-Line Arguments
+
+### `--games`
+Select game types (multiple allowed)
+
+**Options:** `maze`, `irregular_maze`, `maze3d`, `sokoban`, `trapfield`
+
+```bash
+python test_dynamic_metadata.py --games maze sokoban
+```
+
+### `--skins`
+Select skin IDs (multiple allowed)
+
+**Options:** `1`, `2`, `3`, `4`, `5` (varies by game type)
+
+**Skin counts:**
+- maze: 5 skins
+- irregular_maze: 4 skins
+- maze3d: 4 skins
+- sokoban: 5 skins
+- trapfield: 4 skins
+
+```bash
+python test_dynamic_metadata.py --skins 1 2 3
+```
+
+### `--difficulties`
+Select difficulty levels (multiple allowed)
+
+**Options:** `easy`, `medium`, `hard`
+
+```bash
+python test_dynamic_metadata.py --difficulties easy hard
+```
+
+### `--splits`
+Select dataset splits (default: train eval)
+
+**Options:** `train`, `eval`
+
+```bash
+python test_dynamic_metadata.py --splits train
+```
+
+### `--merge`
+Merge all matching data into a single metadata.csv
+
+```bash
+python test_dynamic_metadata.py --games maze --skins 1 2 --merge
+```
+
+### `--dataset-root`
+Specify dataset root directory (default: project_root/downloaded_dataset)
+
+```bash
+python test_dynamic_metadata.py --dataset-root /path/to/dataset
+```
+
+### `--skins-root`
+Specify skins configuration directory (default: project_root/skins)
+
+```bash
+python test_dynamic_metadata.py --skins-root /path/to/skins
+```
+
+## Usage Examples
+
+### Generate all data
+```bash
+python test_dynamic_metadata.py
+```
+**Output:** 132 metadata.csv files (66 train + 66 eval)
+
+### Generate specific game
+```bash
+python test_dynamic_metadata.py --games maze
+```
+**Output:** 30 files (5 skins × 3 difficulties × 2 splits)
+
+### Generate specific combination
+```bash
+python test_dynamic_metadata.py --games maze --skins 1 --difficulties easy
+```
+**Output:** 2 files (train/maze_1_easy and eval/maze_1_easy)
+
+### Merge multiple games
+```bash
+python test_dynamic_metadata.py --games maze irregular_maze --merge
+```
+**Output:** 2 merged files (one for train, one for eval)
+
+### Cross-skin training
+```bash
+python test_dynamic_metadata.py --games maze --skins 1 2 3 --merge --splits train
+```
+**Output:** 1 merged file containing all train data for maze skins 1, 2, 3
+
+### Regenerate specific skins
+```bash
+python test_dynamic_metadata.py --games irregular_maze --skins 1 2 3
+```
+**Output:** 18 files (3 skins × 3 difficulties × 2 splits)
+
+## Output Structure
+
+### Separate Mode (default)
+```
+downloaded_dataset/
+└── metadata/
+    ├── train/
+    │   ├── maze_1_easy/
+    │   │   └── metadata.csv
+    │   ├── maze_1_medium/
+    │   │   └── metadata.csv
+    │   └── ...
+    └── eval/
+        ├── maze_1_easy/
+        │   └── metadata.csv
+        └── ...
+```
+
+### Merge Mode
+```
+downloaded_dataset/
+└── metadata/
+    ├── train/
+    │   └── maze_sokoban_1_2_easy/
+    │       └── metadata.csv
+    └── eval/
+        └── maze_sokoban_1_2_easy/
+            └── metadata.csv
+```
+
+## Metadata CSV Format
+
+Each CSV file contains 3 columns:
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| `video` | Video file path (relative to downloaded_dataset/) | `train/maze/1/easy/videos/easy_0001_0.mp4` |
+| `prompt` | Dynamically generated prompt | `Create a 2D animation...` |
+| `input_image` | Input image path (relative to downloaded_dataset/) | `train/maze/1/easy/images/easy_0001.png` |
+
+## Dynamic Prompt System
+
+Prompts are automatically generated based on skin configurations in `skins/{game_type}/{skin_id}/description.json`.
+
+**Example:** For maze skin 1:
+```json
+{
+  "visual_description": {
+    "player": "red circle",
+    "goal": "green square",
+    "wall": "light blue square",
+    "floor": "white square"
+  }
+}
+```
+
+**Generated prompt:**
+```
+Create a 2D animation based on the provided image of a maze.
+The red circle slides smoothly along the white square path,
+stopping perfectly on the green square...
+```
+
+Different skins produce different prompts automatically.
+
+## Notes
+
+- All paths in metadata.csv are relative to `downloaded_dataset/` directory
+- Game type `irregular_maze` maps to `pathfinder` skin directory
+- If skin description is not found, a warning is displayed and the combination is skipped
+- Use `--merge` mode for training across multiple skins or game types

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""
+Video Model Prompts 模块。
+
+提供基于皮肤配置的动态 prompt 生成功能。
+"""
+import json
+from pathlib import Path
+from typing import Optional
+
+from .videomodel_maze_prompt import get_maze_prompt
+from .videomodel_maze3d_prompt import get_maze3d_prompt
+from .videomodel_sokoban_prompt import get_sokoban_prompt
+from .videomodel_trapfield_prompt import get_trapfield_prompt
+from .videomodel_pathfinder_prompt import get_pathfinder_prompt
+
+# 游戏类型别名映射
+GAME_ALIASES = {
+    "irregular_maze": "pathfinder",
+    "regular_maze": "maze",
+    "3d_maze": "maze3d",
+}
+
+# 游戏类型到 prompt 生成函数的映射
+PROMPT_GENERATORS = {
+    "maze": get_maze_prompt,
+    "maze3d": get_maze3d_prompt,
+    "sokoban": get_sokoban_prompt,
+    "trapfield": get_trapfield_prompt,
+    "pathfinder": get_pathfinder_prompt,
+}
+
+
+def load_skin_description(skins_root: Path, game_type: str, skin_id: str) -> Optional[dict]:
+    """
+    加载皮肤的 description.json 文件。
+    
+    Args:
+        skins_root: skins 目录的根路径
+        game_type: 游戏类型 (maze, maze3d, sokoban, trapfield, pathfinder)
+        skin_id: 皮肤 ID (1, 2, 3, ...)
+    
+    Returns:
+        description.json 的内容，或 None（如果文件不存在）
+    """
+    # 处理游戏类型别名
+    canonical_game_type = GAME_ALIASES.get(game_type, game_type)
+    
+    desc_path = skins_root / canonical_game_type / skin_id / "description.json"
+    
+    if not desc_path.exists():
+        return None
+    
+    with open(desc_path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def get_dynamic_prompt(
+    game_type: str,
+    skin_id: str,
+    skins_root: Optional[Path] = None,
+) -> str:
+    """
+    根据游戏类型和皮肤 ID 生成动态 prompt。
+    
+    Args:
+        game_type: 游戏类型 (maze, maze3d, sokoban, trapfield, pathfinder, irregular_maze, regular_maze)
+        skin_id: 皮肤 ID
+        skins_root: skins 目录的根路径，默认为 VR-Bench/skins
+    
+    Returns:
+        生成的 prompt 字符串
+    
+    Raises:
+        ValueError: 如果游戏类型不支持或找不到皮肤描述文件
+    """
+    # 处理游戏类型别名
+    canonical_game_type = GAME_ALIASES.get(game_type, game_type)
+    
+    # 检查游戏类型是否支持
+    if canonical_game_type not in PROMPT_GENERATORS:
+        raise ValueError(f"Unsupported game type: {game_type}")
+    
+    # 确定 skins 目录路径
+    if skins_root is None:
+        # 默认路径: VR-Bench/skins (相对于此文件)
+        skins_root = Path(__file__).parent.parent / "skins"
+    
+    # 加载皮肤描述
+    description = load_skin_description(skins_root, canonical_game_type, skin_id)
+    
+    if description is None:
+        raise ValueError(
+            f"Skin description not found: skins/{canonical_game_type}/{skin_id}/description.json"
+        )
+    
+    visual_description = description.get("visual_description", {})
+    
+    if not visual_description:
+        raise ValueError(
+            f"visual_description is empty in skins/{canonical_game_type}/{skin_id}/description.json"
+        )
+    
+    # 生成 prompt
+    generator = PROMPT_GENERATORS[canonical_game_type]
+    return generator(visual_description)
+
+
+__all__ = [
+    "get_dynamic_prompt",
+    "load_skin_description",
+    "GAME_ALIASES",
+    "PROMPT_GENERATORS",
+]
+

--- a/prompts/generate_metadata.py
+++ b/prompts/generate_metadata.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+"""
+数据集 metadata 生成工具。
+
+支持灵活选择多种迷宫、皮肤和难度的组合生成 metadata.csv 文件。
+使用动态 prompt 系统，根据皮肤配置生成对应的 prompt。
+"""
+import csv
+import argparse
+from pathlib import Path
+from collections import defaultdict
+from typing import List, Optional
+
+from . import get_dynamic_prompt, GAME_ALIASES
+
+DATASET_ROOT = "downloaded_dataset"
+
+# skins 目录相对于此文件的路径
+SKINS_ROOT = Path(__file__).parent.parent / "skins"
+
+
+def get_image_video_pairs(difficulty_dir: Path, split_name: str, game_type: str, skin_id: str, difficulty: str) -> list:
+    """获取图片和视频配对，返回相对路径。"""
+    images_dir = difficulty_dir / "images"
+    videos_dir = difficulty_dir / "videos"
+
+    if not images_dir.exists() or not videos_dir.exists():
+        return []
+
+    image_files = sorted(images_dir.glob("*.png"))
+    pairs = []
+
+    for image_path in image_files:
+        base_name = image_path.stem
+        video_files = []
+
+        # 查找带数字后缀的视频（如 xxx_0.mp4, xxx_1.mp4）
+        for video_path in sorted(videos_dir.glob(f"{base_name}_*.mp4")):
+            suffix = video_path.stem[len(base_name) + 1:]
+            if suffix.isdigit():
+                video_files.append(video_path)
+
+        # 如果没有找到，查找不带后缀的视频
+        if not video_files:
+            video_path = videos_dir / f"{base_name}.mp4"
+            if video_path.exists():
+                video_files.append(video_path)
+
+        if video_files:
+            for video_path in video_files:
+                video_rel = f"{split_name}/{game_type}/{skin_id}/{difficulty}/videos/{video_path.name}"
+                image_rel = f"{split_name}/{game_type}/{skin_id}/{difficulty}/images/{image_path.name}"
+                pairs.append({'video': video_rel, 'image': image_rel})
+
+    return pairs
+
+
+def collect_all_data(
+    dataset_root: Path,
+    split_name: str,
+    game_types: Optional[List[str]] = None,
+    skin_ids: Optional[List[str]] = None,
+    difficulties: Optional[List[str]] = None,
+    skins_root: Optional[Path] = None,
+) -> dict:
+    """收集数据并按 {game_type}_{skin_id}_{difficulty} 分组，使用动态 prompt。"""
+    split_dir = dataset_root / split_name
+
+    if not split_dir.exists():
+        print(f"Split directory not found: {split_dir}")
+        return {}
+
+    if difficulties is None:
+        difficulties = ['easy', 'medium', 'hard']
+
+    if skins_root is None:
+        skins_root = SKINS_ROOT
+
+    grouped_data = defaultdict(list)
+
+    for game_dir in sorted(split_dir.iterdir()):
+        if not game_dir.is_dir():
+            continue
+
+        game_type = game_dir.name
+
+        # 过滤游戏类型
+        if game_types and game_type not in game_types:
+            continue
+
+        for skin_dir in sorted(game_dir.iterdir()):
+            if not skin_dir.is_dir():
+                continue
+
+            skin_id = skin_dir.name
+
+            # 过滤皮肤ID
+            if skin_ids and skin_id not in skin_ids:
+                continue
+
+            # 为每个 (game_type, skin_id) 组合生成动态 prompt
+            try:
+                prompt = get_dynamic_prompt(game_type, skin_id, skins_root)
+            except ValueError as e:
+                print(f"  Warning: {e}")
+                prompt = ""
+
+            for difficulty in difficulties:
+                difficulty_dir = skin_dir / difficulty
+                if not difficulty_dir.exists():
+                    continue
+
+                pairs = get_image_video_pairs(difficulty_dir, split_name, game_type, skin_id, difficulty)
+                group_key = f"{game_type}_{skin_id}_{difficulty}"
+
+                for pair in pairs:
+                    grouped_data[group_key].append({
+                        'video': pair['video'],
+                        'image': pair['image'],
+                        'prompt': prompt
+                    })
+
+    return grouped_data
+
+
+def write_metadata_csv(output_dir: Path, data: list) -> int:
+    """写入 metadata.csv 文件。"""
+    if not data:
+        return 0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "metadata.csv"
+
+    with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(['video', 'prompt', 'input_image'])
+
+        for item in data:
+            writer.writerow([item['video'], item['prompt'], item['image']])
+
+    return len(data)
+
+
+def process_split(
+    dataset_root: Path,
+    split_name: str,
+    metadata_root: Path,
+    game_types: Optional[List[str]] = None,
+    skin_ids: Optional[List[str]] = None,
+    difficulties: Optional[List[str]] = None,
+    merge_mode: str = 'separate',
+    skins_root: Optional[Path] = None,
+):
+    """处理单个数据集分割。"""
+    print(f"\n{'=' * 60}")
+    print(f"Processing {split_name} split")
+    print('=' * 60)
+
+    grouped_data = collect_all_data(
+        dataset_root, split_name, game_types, skin_ids, difficulties, skins_root
+    )
+
+    if not grouped_data:
+        print(f"No data found for {split_name}")
+        return
+
+    output_split_dir = metadata_root / split_name
+    output_split_dir.mkdir(parents=True, exist_ok=True)
+
+    total_entries = 0
+    total_groups = 0
+
+    if merge_mode == 'merge':
+        # 合并模式：所有数据合并到一个 metadata.csv
+        all_data = []
+        for data in grouped_data.values():
+            all_data.extend(data)
+
+        # 生成合并后的文件名
+        parts = []
+        if game_types:
+            parts.append('_'.join(sorted(game_types)))
+        if skin_ids:
+            parts.append('_'.join(sorted(skin_ids)))
+        if difficulties:
+            parts.append('_'.join(sorted(difficulties)))
+
+        merged_name = '_'.join(parts) if parts else 'all'
+        merged_dir = output_split_dir / merged_name
+
+        count = write_metadata_csv(merged_dir, all_data)
+        print(f"  {merged_name}: {count} entries (merged)")
+        total_entries = count
+        total_groups = 1
+    else:
+        # 分离模式：每个组合单独生成 metadata.csv
+        for group_key, data in sorted(grouped_data.items()):
+            group_dir = output_split_dir / group_key
+            count = write_metadata_csv(group_dir, data)
+
+            if count > 0:
+                print(f"  {group_key}: {count} entries")
+                total_entries += count
+                total_groups += 1
+
+    print(f"\nTotal groups: {total_groups}")
+    print(f"Total entries: {total_entries}")
+
+
+def parse_args():
+    """解析命令行参数。"""
+    parser = argparse.ArgumentParser(
+        description='生成数据集 metadata.csv 文件，支持灵活选择游戏类型、皮肤和难度',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+示例用法:
+
+1. 生成所有数据（默认）:
+   python generate_metadata.py
+
+2. 只生成 maze 和 maze3d 的数据:
+   python generate_metadata.py --games maze maze3d
+
+3. 只生成皮肤 1 和 2 的数据:
+   python generate_metadata.py --skins 1 2
+
+4. 只生成 easy 和 medium 难度:
+   python generate_metadata.py --difficulties easy medium
+
+5. 组合条件（maze 游戏，皮肤 1，easy 难度）:
+   python generate_metadata.py --games maze --skins 1 --difficulties easy
+
+6. 合并模式（将所有符合条件的数据合并到一个 metadata.csv）:
+   python generate_metadata.py --games maze sokoban --merge
+
+7. 只处理 train 数据集:
+   python generate_metadata.py --splits train
+
+8. 复杂组合（多游戏、多皮肤、多难度，合并）:
+   python generate_metadata.py --games maze irregular_maze --skins 1 2 3 --difficulties easy hard --merge
+        """
+    )
+
+    parser.add_argument(
+        '--games',
+        nargs='+',
+        choices=['maze', 'irregular_maze', 'maze3d', 'sokoban', 'trapfield'],
+        help='选择游戏类型（可多选）'
+    )
+
+    parser.add_argument(
+        '--skins',
+        nargs='+',
+        help='选择皮肤ID（可多选，如: 1 2 3）'
+    )
+
+    parser.add_argument(
+        '--difficulties',
+        nargs='+',
+        choices=['easy', 'medium', 'hard'],
+        help='选择难度（可多选）'
+    )
+
+    parser.add_argument(
+        '--splits',
+        nargs='+',
+        choices=['train', 'eval'],
+        default=['train', 'eval'],
+        help='选择数据集分割（默认: train eval）'
+    )
+
+    parser.add_argument(
+        '--merge',
+        action='store_true',
+        help='合并模式：将所有符合条件的数据合并到一个 metadata.csv'
+    )
+
+    parser.add_argument(
+        '--dataset-root',
+        default=DATASET_ROOT,
+        help=f'数据集根目录（默认: {DATASET_ROOT}）'
+    )
+
+    parser.add_argument(
+        '--skins-root',
+        default=None,
+        help='皮肤目录根路径（默认: VR-Bench/skins）'
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    dataset_root = Path(args.dataset_root)
+    skins_root = Path(args.skins_root) if args.skins_root else SKINS_ROOT
+
+    print("=" * 60)
+    print("Generating metadata structure (with dynamic prompts)")
+    print(f"Dataset root: {dataset_root.absolute()}")
+    print(f"Skins root: {skins_root.absolute()}")
+    print("=" * 60)
+
+    # 显示过滤条件
+    if args.games:
+        print(f"Game types: {', '.join(args.games)}")
+    if args.skins:
+        print(f"Skin IDs: {', '.join(args.skins)}")
+    if args.difficulties:
+        print(f"Difficulties: {', '.join(args.difficulties)}")
+    print(f"Splits: {', '.join(args.splits)}")
+    print(f"Mode: {'merge' if args.merge else 'separate'}")
+    print("=" * 60)
+
+    if not dataset_root.exists():
+        print(f"Error: Dataset root not found: {dataset_root}")
+        return
+
+    if not skins_root.exists():
+        print(f"Warning: Skins root not found: {skins_root}")
+        print("Dynamic prompts may fail for some game types.")
+
+    metadata_root = dataset_root / "metadata"
+    metadata_root.mkdir(exist_ok=True)
+
+    merge_mode = 'merge' if args.merge else 'separate'
+
+    for split in args.splits:
+        process_split(
+            dataset_root,
+            split,
+            metadata_root,
+            game_types=args.games,
+            skin_ids=args.skins,
+            difficulties=args.difficulties,
+            merge_mode=merge_mode,
+            skins_root=skins_root,
+        )
+
+    print("\n" + "=" * 60)
+    print("Done!")
+    print(f"Metadata files created in: {metadata_root.absolute()}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/prompts/videomodel_maze3d_prompt.py
+++ b/prompts/videomodel_maze3d_prompt.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Maze3D 游戏的视频模型 prompt 模板。
+
+占位符: {ball}, {start_cube}, {goal_cube}, {default_cube}
+从 description.json 的 visual_description 中读取。
+"""
+from string import Template
+
+MAZE3D_PROMPT_TEMPLATE = Template("""Create a 3D animation based on the provided image of a cube maze. A $ball slides smoothly along the $default_cube pathway, climbs up the vertical ladders step by step, and finally stops perfectly on the $goal_cube at the top. The $ball never touches or passes through the $start_cube or any non-$default_cube areas of the maze. The camera remains static in an isometric, top-down angle showing the entire structure.
+
+Maze:
+ The maze consists of stacked transparent $default_cube forming a 3D pathway.
+ The $goal_cube represents the goal position.
+ The $start_cube marks the starting platform where the $ball begins.
+ The $ball moves upward along the $default_cube path, climbing vertically via the ladders.
+ The ball slides smoothly without sudden changes in direction or speed.
+ The ball stops exactly on top of the $goal_cube at the end.
+
+Scene:
+ No structural or color changes during animation.
+ The maze layout and cube arrangement remain unchanged.
+ The $ball moves continuously at a constant speed along the 3D path.
+
+Camera:
+ Static, isometric camera view.
+ No zoom or pan.
+ Smooth animation without flicker, noise, or artifacts.""")
+
+
+def get_maze3d_prompt(visual_description: dict) -> str:
+    """
+    生成 maze3d 游戏的动态 prompt。
+    
+    Args:
+        visual_description: 来自 description.json 的 visual_description 字段
+            - ball: 球的描述 (如 "golden ball with orange edge")
+            - start_cube: 起点方块描述 (如 "blue cube")
+            - goal_cube: 目标方块描述 (如 "red cube")
+            - default_cube: 默认路径方块描述 (如 "gray cube")
+    """
+    return MAZE3D_PROMPT_TEMPLATE.substitute(
+        ball=visual_description.get("ball", "yellow ball"),
+        start_cube=visual_description.get("start_cube", "blue cube"),
+        goal_cube=visual_description.get("goal_cube", "red cube"),
+        default_cube=visual_description.get("default_cube", "gray cube"),
+    )
+

--- a/prompts/videomodel_maze_prompt.py
+++ b/prompts/videomodel_maze_prompt.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Maze 游戏的视频模型 prompt 模板。
+
+占位符: {player}, {goal}, {wall}, {floor}
+从 description.json 的 visual_description 中读取。
+"""
+from string import Template
+
+MAZE_PROMPT_TEMPLATE = Template("""Create a 2D animation based on the provided image of a maze. The $player slides smoothly along the $floor path, stopping perfectly on the $goal. The $player never slides or crosses into the $wall areas of the maze. The camera is a static, top-down view showing the entire maze.
+
+Maze:
+ The maze paths are $floor, the walls are $wall.
+ The $player moves to the goal position, represented by $goal.
+ The $player slides smoothly along the $floor path.
+ The $player never slides or crosses into the $wall areas of the maze.
+ The $player stops perfectly on the $goal.
+
+Scene:
+ No change in scene composition.
+ No change in the layout of the maze.
+ The $player travels along the $floor path without speeding up or slowing down.
+
+Camera:
+ Static camera.
+ No zoom.
+ No pan.
+ No glitches, noise, or artifacts.""")
+
+
+def get_maze_prompt(visual_description: dict) -> str:
+    """
+    生成 maze 游戏的动态 prompt。
+    
+    Args:
+        visual_description: 来自 description.json 的 visual_description 字段
+            - player: 玩家描述 (如 "red circle")
+            - goal: 目标描述 (如 "green square")
+            - wall: 墙壁描述 (如 "light blue square")
+            - floor: 地板描述 (如 "white square")
+    """
+    return MAZE_PROMPT_TEMPLATE.substitute(
+        player=visual_description.get("player", "red circle"),
+        goal=visual_description.get("goal", "green square"),
+        wall=visual_description.get("wall", "blue"),
+        floor=visual_description.get("floor", "white"),
+    )
+

--- a/prompts/videomodel_pathfinder_prompt.py
+++ b/prompts/videomodel_pathfinder_prompt.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+Pathfinder (irregular_maze) 游戏的视频模型 prompt 模板。
+
+占位符: {start}, {end}, {road}
+从 description.json 的 visual_description 中读取。
+"""
+from string import Template
+
+PATHFINDER_PROMPT_TEMPLATE = Template("""Create a 2D animation based on the provided image of a maze. The $start slides smoothly along the $road path, stopping perfectly on the $end. The $start never slides or crosses into the black areas of the maze. The camera is a static, top-down view showing the entire maze.
+
+Maze:
+ The maze paths are $road, the walls are black.
+ The $start moves to the goal position, represented by $end.
+ The $start slides smoothly along the $road path.
+ The $start never slides or crosses into the black areas of the maze.
+ The $start stops perfectly on the $end.
+
+Scene:
+ No change in scene composition.
+ No change in the layout of the maze.
+ The $start travels along the $road path without speeding up or slowing down.
+
+Camera:
+ Static camera.
+ No zoom.
+ No pan.
+ No glitches, noise, or artifacts.""")
+
+
+def get_pathfinder_prompt(visual_description: dict) -> str:
+    """
+    生成 pathfinder 游戏的动态 prompt。
+    
+    Args:
+        visual_description: 来自 description.json 的 visual_description 字段
+            - start: 起点描述 (如 "green circle")
+            - end: 终点描述 (如 "red circle")
+            - road: 道路描述 (如 "white square")
+    """
+    return PATHFINDER_PROMPT_TEMPLATE.substitute(
+        start=visual_description.get("start", "green circle"),
+        end=visual_description.get("end", "red circle"),
+        road=visual_description.get("road", "white path"),
+    )
+

--- a/prompts/videomodel_sokoban_prompt.py
+++ b/prompts/videomodel_sokoban_prompt.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Sokoban 游戏的视频模型 prompt 模板。
+
+占位符: {player}, {box}, {goal}, {wall}, {floor}
+从 description.json 的 visual_description 中读取。
+"""
+from string import Template
+
+SOKOBAN_PROMPT_TEMPLATE = Template("""Create a 2D animation based on the provided image of a grid puzzle.
+The $player moves into position behind the $box and smoothly pushes it toward the $goal.
+The $box only slides when pushed from behind by the $player and moves in a straight line along the $floor tiles.
+When the direction of the $box's movement needs to change, the $player must reposition itself to a new side of the $box.
+The $box never crosses or overlaps any $wall.
+
+Gameplay Rules:
+The floor area is $floor, and the walls are $wall.
+The $box can only move when pushed by the $player from behind.
+The $player cannot pull the $box or move through walls.
+The $box slides smoothly in one direction until it reaches the $goal.
+The animation stops perfectly when the $box aligns with the $goal.
+
+Scene:
+No change in grid layout or tile design.
+The camera remains static, showing the entire play area.
+The movement is smooth, with no speed variation, camera shake, or visual artifacts.""")
+
+
+def get_sokoban_prompt(visual_description: dict) -> str:
+    """
+    生成 sokoban 游戏的动态 prompt。
+    
+    Args:
+        visual_description: 来自 description.json 的 visual_description 字段
+            - player: 玩家描述 (如 "blue circle")
+            - box: 箱子描述 (如 "yellow square")
+            - goal: 目标描述 (如 "pink square")
+            - wall: 墙壁描述 (如 "gray square")
+            - floor: 地板描述 (如 "white square")
+    """
+    return SOKOBAN_PROMPT_TEMPLATE.substitute(
+        player=visual_description.get("player", "blue ball"),
+        box=visual_description.get("box", "yellow square"),
+        goal=visual_description.get("goal", "red square"),
+        wall=visual_description.get("wall", "gray wall"),
+        floor=visual_description.get("floor", "white floor"),
+    )
+

--- a/prompts/videomodel_trapfield_prompt.py
+++ b/prompts/videomodel_trapfield_prompt.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Trapfield 游戏的视频模型 prompt 模板。
+
+占位符: {player}, {goal}, {trap}, {floor}
+从 description.json 的 visual_description 中读取。
+"""
+from string import Template
+
+TRAPFIELD_PROMPT_TEMPLATE = Template("""Create a 2D animation based on the provided image of a maze. The $player slides smoothly along the $floor path, stopping perfectly on the $goal. The $player never slides into or crosses the $trap (trap areas). The camera is a static, top-down view showing the entire maze.
+
+Maze:
+ The maze paths are $floor, and the trap areas are $trap.
+ The $player moves to the goal position, represented by the $goal.
+ The $player slides smoothly along the $floor path.
+ The $player never slides into or crosses the $trap of the maze.
+ The $player stops perfectly on the $goal.
+
+Scene:
+ No change in scene composition.
+ No change in the layout of the maze.
+ The $player travels along the $floor path without speeding up or slowing down.
+
+Camera:
+ Static camera.
+ No zoom.
+ No pan.
+ No glitches, noise, or artifacts.""")
+
+
+def get_trapfield_prompt(visual_description: dict) -> str:
+    """
+    生成 trapfield 游戏的动态 prompt。
+    
+    Args:
+        visual_description: 来自 description.json 的 visual_description 字段
+            - player: 玩家描述 (如 "blue circle")
+            - goal: 目标描述 (如 "green circle")
+            - trap: 陷阱描述 (如 "red x")
+            - floor: 地板描述 (如 "white square")
+    """
+    return TRAPFIELD_PROMPT_TEMPLATE.substitute(
+        player=visual_description.get("player", "blue circle"),
+        goal=visual_description.get("goal", "green circle"),
+        trap=visual_description.get("trap", "red cross"),
+        floor=visual_description.get("floor", "gray path"),
+    )
+

--- a/skins/pathfinder/1/description.json
+++ b/skins/pathfinder/1/description.json
@@ -4,6 +4,6 @@
   "visual_description": {
     "start": "green circle",
     "end": "red circle",
-    "road": "white square"
+    "road": "white"
   }
 }

--- a/skins/pathfinder/2/description.json
+++ b/skins/pathfinder/2/description.json
@@ -4,6 +4,6 @@
   "visual_description": {
     "start": "white golf ball",
     "end": "golf hole",
-    "road": "green grass field"
+    "road": "green grass"
   }
 }

--- a/skins/pathfinder/3/description.json
+++ b/skins/pathfinder/3/description.json
@@ -4,6 +4,6 @@
   "visual_description": {
     "start": "blue ice ball",
     "end": "blue circle",
-    "road": "icy texture"
+    "road": "icy"
   }
 }


### PR DESCRIPTION
Replace hardcoded prompts with a dynamic prompt system that generates skin-specific prompts from `description.json` files.

### Changes

**New Files:**
- `prompts/__init__.py` - Module entry with `get_dynamic_prompt(game_type, skin_id, skins_root)` API
- `prompts/videomodel_{maze,maze3d,sokoban,trapfield,pathfinder}_prompt.py` - Template-based prompt generators for each game type

**Modified:**
- `prompts/generate_metadata.py`
  - Removed hardcoded `DATASET_PROMPTS` dictionary
  - Integrated dynamic prompt loading from `skins/{game_type}/{skin_id}/description.json`
  - Added `--skins-root` CLI argument

### Usage

```bash
# Prompts now auto-generated based on skin's visual_description
python -m prompts.generate_metadata --games maze --skins 1 2
```

### Before/After

| Before                                                       | After                                                        |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| `"The red circle slides along the white path..."` (hardcoded) | `"The {player} slides along the {floor} path..."` → `"The blue square slides along the gray path..."` (from skin config) |